### PR TITLE
Switch to BitcoinZ forks for Zcash/Orchard crates (fix 21M cap)

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -72,3 +72,13 @@ tempdir = "0.3.7"
 
 [build-dependencies]
 tonic-build = "0.7.2"
+
+
+[patch.crates-io]
+zcash_address = { git = "https://github.com/z-bitcoinz/librustzcash-bitcoinz", rev = "8190688b" }
+zcash_primitives = { git = "https://github.com/z-bitcoinz/librustzcash-bitcoinz", rev = "8190688b" }
+zcash_client_backend = { git = "https://github.com/z-bitcoinz/librustzcash-bitcoinz", rev = "8190688b" }
+zcash_note_encryption = { git = "https://github.com/z-bitcoinz/librustzcash-bitcoinz", rev = "8190688b" }
+zcash_encoding = { git = "https://github.com/z-bitcoinz/librustzcash-bitcoinz", rev = "8190688b" }
+zcash_proofs = { git = "https://github.com/z-bitcoinz/librustzcash-bitcoinz", rev = "8190688b" }
+orchard = { git = "https://github.com/z-bitcoinz/orchard-bitcoinz", branch = "bitcoinz-21b-supply" }

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -28,10 +28,10 @@ lazy_static = "1.4.0"
 
 
 [patch.crates-io]
-zcash_address = { git = "https://github.com/adityapk00/librustzcash", rev = "adf49f8b848a5ac85e1476354614eeae9880206a"}
-zcash_primitives = { git = "https://github.com/adityapk00/librustzcash", rev = "adf49f8b848a5ac85e1476354614eeae9880206a"}
-zcash_client_backend = { git = "https://github.com/adityapk00/librustzcash", rev = "adf49f8b848a5ac85e1476354614eeae9880206a"}
-zcash_note_encryption = { git = "https://github.com/adityapk00/librustzcash", rev = "adf49f8b848a5ac85e1476354614eeae9880206a"}
-zcash_encoding = { git = "https://github.com/adityapk00/librustzcash", rev = "adf49f8b848a5ac85e1476354614eeae9880206a"}
-zcash_proofs = { git = "https://github.com/adityapk00/librustzcash", rev = "adf49f8b848a5ac85e1476354614eeae9880206a"}
-orchard = { git = "https://github.com/adityapk00/orchard", rev = "0a960a380f4e9c3472c9260f3df61cd5e50d51b0" }
+zcash_address = { git = "https://github.com/z-bitcoinz/librustzcash-bitcoinz", rev = "8190688b" }
+zcash_primitives = { git = "https://github.com/z-bitcoinz/librustzcash-bitcoinz", rev = "8190688b" }
+zcash_client_backend = { git = "https://github.com/z-bitcoinz/librustzcash-bitcoinz", rev = "8190688b" }
+zcash_note_encryption = { git = "https://github.com/z-bitcoinz/librustzcash-bitcoinz", rev = "8190688b" }
+zcash_encoding = { git = "https://github.com/z-bitcoinz/librustzcash-bitcoinz", rev = "8190688b" }
+zcash_proofs = { git = "https://github.com/z-bitcoinz/librustzcash-bitcoinz", rev = "8190688b" }
+orchard = { git = "https://github.com/z-bitcoinz/orchard-bitcoinz", branch = "bitcoinz-21b-supply" }


### PR DESCRIPTION
This PR redirects Zcash/Orchard crates to BitcoinZ forks to remove the upstream 21M cap and support large BTCZ transactions.

Changes:
- Patch zcash_* crates to https://github.com/z-bitcoinz/librustzcash-bitcoinz (rev 8190688b)
- Patch orchard to https://github.com/z-bitcoinz/orchard-bitcoinz (branch bitcoinz-21b-supply)
- Apply identical [patch.crates-io] in lib/Cargo.toml and native/Cargo.toml

Local checks:
- cargo check (lib and native) succeeded

Merging this will ensure builds use the BTCZ-specific consensus parameters. CI should run on this PR and on the branch.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author