### PR TITLE
UI: “Change returning soon” tile + remove duplicate success line

### DIFF
--- a/src/components/Send.tsx
+++ b/src/components/Send.tsx
@@ -953,6 +953,15 @@ export default class Send extends PureComponent<Props, SendState> {
               usdValue={Utils.getBtczToUsdStringBtcz(info.btczPrice, totalBalance.total)}
               currencyName={info.currencyName}
             />
+            {totalBalance.pendingChange > 0 && (
+              <BalanceBlockHighlight
+                topLabel="Change returning soon"
+                zecValue={totalBalance.pendingChange}
+                usdValue={Utils.getBtczToUsdStringBtcz(info.btczPrice, totalBalance.pendingChange)}
+                currencyName={info.currencyName}
+                tooltip="Your change will return soon after the network confirms (~1–2 min)"
+              />
+            )}
             {totalBalance.totalPending > 0 && (
               <BalanceBlockHighlight
                 topLabel="Pending"
@@ -963,12 +972,6 @@ export default class Send extends PureComponent<Props, SendState> {
             )}
           </div>
 
-            {totalBalance.pendingChange > 0 && (
-              <div className={[cstyles.sublight, cstyles.small].join(" ")}
-                   title="When you send, any extra comes back to you as 'change'. It becomes available after the network confirms (~1–2 min).">
-                <i className="fas fa-clock" /> Change pending: {Utils.maxPrecisionTrimmedBtcz(totalBalance.pendingChange)} BTCZ — returns after confirmation (~1–2 min)
-              </div>
-            )}
 
 
 

--- a/src/components/TransactionSuccessModal.tsx
+++ b/src/components/TransactionSuccessModal.tsx
@@ -150,13 +150,6 @@ export const TransactionSuccessModal = ({ title, txid, modalIsOpen, closeModal, 
           borderRadius: "10px",
           border: "1px solid rgba(255, 255, 255, 0.15)"
         }}>
-          <div style={{
-            marginBottom: "12px",
-            fontSize: "14px",
-            fontWeight: "500"
-          }}>
-            Transaction was successfully broadcast.
-          </div>
             <div style={{ fontSize: "11px", color: "rgba(255, 255, 255, 0.8)" }}>
             <div style={{ display: "none" }}>
 


### PR DESCRIPTION
- Send page: add a BalanceBlock tile labeled **Change returning soon** showing `pendingChange`, with tooltip explaining it confirms in ~1–2 min.
- Transaction success modal: remove duplicate inner line "Transaction was successfully broadcast." leaving the title and explanatory text only.

This keeps the success dialog concise and makes the temporary reduction in available balance clearer to users.

Please review; once approved and merged, I can follow up with any copy tweaks if needed.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author