### PR TITLE
fix: Apply proxy settings to LightClient initialization

### DIFF
--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -50,16 +50,22 @@ fn litelib_wallet_exists(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 /// Create a new wallet and return the seed for the newly created wallet.
 fn litelib_initialize_new(mut cx: FunctionContext) -> JsResult<JsString> {
     let server_uri = cx.argument::<JsString>(0)?.value(&mut cx);
+    let proxy_enabled = cx.argument::<JsBoolean>(1)?.value(&mut cx);
+    let proxy_url = cx.argument::<JsString>(2)?.value(&mut cx);
 
     let resp = || {
         let server = LightClientConfig::<MainNetwork>::get_server_or_default(Some(server_uri));
-        let (config, latest_block_height) =
+        let (mut config, latest_block_height) =
             match LightClientConfig::create(MainNetwork, server, None) {
                 Ok((c, h)) => (c, h),
                 Err(e) => {
                     return format!("Error: {}", e);
                 }
             };
+
+        // Apply proxy configuration
+        config.proxy_config.enabled = proxy_enabled;
+        config.proxy_config.url = proxy_url;
 
         let lightclient = match LightClient::new(&config, latest_block_height.saturating_sub(100)) {
             Ok(l) => l,
@@ -96,16 +102,22 @@ fn litelib_initialize_new_from_phrase(mut cx: FunctionContext) -> JsResult<JsStr
     let seed = cx.argument::<JsString>(1)?.value(&mut cx);
     let birthday = cx.argument::<JsNumber>(2)?.value(&mut cx);
     let overwrite = cx.argument::<JsBoolean>(3)?.value(&mut cx);
+    let proxy_enabled = cx.argument::<JsBoolean>(4)?.value(&mut cx);
+    let proxy_url = cx.argument::<JsString>(5)?.value(&mut cx);
 
     let resp = || {
         let server = LightClientConfig::<MainNetwork>::get_server_or_default(Some(server_uri));
-        let (config, _latest_block_height) =
+        let (mut config, _latest_block_height) =
             match LightClientConfig::create(MainNetwork, server, None) {
                 Ok((c, h)) => (c, h),
                 Err(e) => {
                     return format!("Error: {}", e);
                 }
             };
+
+        // Apply proxy configuration
+        config.proxy_config.enabled = proxy_enabled;
+        config.proxy_config.url = proxy_url;
 
         let lightclient =
             match LightClient::new_from_phrase(seed, &config, birthday as u64, overwrite) {
@@ -132,16 +144,22 @@ fn litelib_initialize_new_from_phrase(mut cx: FunctionContext) -> JsResult<JsStr
 // Initialize a new lightclient and store its value
 fn litelib_initialize_existing(mut cx: FunctionContext) -> JsResult<JsString> {
     let server_uri = cx.argument::<JsString>(0)?.value(&mut cx);
+    let proxy_enabled = cx.argument::<JsBoolean>(1)?.value(&mut cx);
+    let proxy_url = cx.argument::<JsString>(2)?.value(&mut cx);
 
     let resp = || {
         let server = LightClientConfig::<MainNetwork>::get_server_or_default(Some(server_uri));
-        let (config, _latest_block_height) =
+        let (mut config, _latest_block_height) =
             match LightClientConfig::create(MainNetwork, server, None) {
                 Ok((c, h)) => (c, h),
                 Err(e) => {
                     return format!("Error: {}", e);
                 }
             };
+
+        // Apply proxy configuration
+        config.proxy_config.enabled = proxy_enabled;
+        config.proxy_config.url = proxy_url;
 
         let lightclient = match LightClient::read_from_disk(&config) {
             Ok(l) => l,

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -24,6 +24,10 @@ class LoadingScreenState {
 
   url: string;
 
+  proxyEnabled: boolean;
+
+  proxyUrl: string;
+
   walletScreen: number; // 0 -> no wallet, load existing wallet 1 -> show option 2-> create new 3 -> restore existing
 
   newWalletError: null | string; // Any errors when creating/restoring wallet
@@ -31,7 +35,7 @@ class LoadingScreenState {
   seed: string; // The new seed phrase for a newly created wallet or the seed phrase to restore from
 
   birthday: number; // Wallet birthday if we're restoring
-  
+
   walletBirthday: number; // The birthday of a newly created wallet
 
   getinfoRetryCount: number;
@@ -42,6 +46,8 @@ class LoadingScreenState {
     this.loadingDone = false;
     this.rpcConfig = null;
     this.url = "";
+    this.proxyEnabled = false;
+    this.proxyUrl = "socks5://127.0.0.1:9050";
     this.getinfoRetryCount = 0;
     this.walletScreen = 0;
     this.newWalletError = null;
@@ -90,10 +96,16 @@ class LoadingScreen extends Component<Props & RouteComponentProps, LoadingScreen
       server = Utils.V3_LIGHTWALLETD;
     }
 
+    // Load proxy settings
+    const proxyEnabled = settings?.proxy?.enabled || false;
+    const proxyUrl = settings?.proxy?.url || "socks5://127.0.0.1:9050";
+
     const newstate = new LoadingScreenState();
     Object.assign(newstate, this.state);
 
     newstate.url = server;
+    newstate.proxyEnabled = proxyEnabled;
+    newstate.proxyUrl = proxyUrl;
     this.setState(newstate);
   };
 
@@ -144,7 +156,8 @@ class LoadingScreen extends Component<Props & RouteComponentProps, LoadingScreen
       this.setState({ walletScreen: 1 });
     } else {
       try {
-        const result = getNativeModule().litelib_initialize_existing(url);
+        const { proxyEnabled, proxyUrl } = this.state;
+        const result = getNativeModule().litelib_initialize_existing(url, proxyEnabled, proxyUrl);
         console.log(`Intialization: ${result}`);
         if (result !== "OK") {
           this.setState({
@@ -369,8 +382,8 @@ class LoadingScreen extends Component<Props & RouteComponentProps, LoadingScreen
   };
 
   createNewWallet = () => {
-    const { url } = this.state;
-    const result = getNativeModule().litelib_initialize_new(url);
+    const { url, proxyEnabled, proxyUrl } = this.state;
+    const result = getNativeModule().litelib_initialize_new(url, proxyEnabled, proxyUrl);
 
     if (result.startsWith("Error")) {
       this.setState({ newWalletError: result });
@@ -409,12 +422,12 @@ class LoadingScreen extends Component<Props & RouteComponentProps, LoadingScreen
   };
 
   doRestoreWallet = () => {
-    const { seed, birthday, url } = this.state;
+    const { seed, birthday, url, proxyEnabled, proxyUrl } = this.state;
     console.log(`Restoring ${seed} with ${birthday}`);
 
     const allowOverwrite = true;
 
-    const result = getNativeModule().litelib_initialize_new_from_phrase(url, seed, birthday, allowOverwrite);
+    const result = getNativeModule().litelib_initialize_new_from_phrase(url, seed, birthday, allowOverwrite, proxyEnabled, proxyUrl);
     if (result.startsWith("Error")) {
       this.setState({ newWalletError: result });
     } else {

--- a/src/native.node.d.ts
+++ b/src/native.node.d.ts
@@ -1,12 +1,14 @@
 export function litelib_say_hello(s: string): string;
 export function litelib_wallet_exists(chain_name: string): boolean;
-export function litelib_initialize_new(server_uri: string): string;
+export function litelib_initialize_new(server_uri: string, proxy_enabled: boolean, proxy_url: string): string;
 export function litelib_initialize_new_from_phrase(
   server_uri: string,
   seed: string,
   birthday: number,
-  overwrite: boolean
+  overwrite: boolean,
+  proxy_enabled: boolean,
+  proxy_url: string
 ): string;
-export function litelib_initialize_existing(server_uri: string): string;
+export function litelib_initialize_existing(server_uri: string, proxy_enabled: boolean, proxy_url: string): string;
 export function litelib_deinitialize(): string;
 export function litelib_execute(cmd: string, args: string): string;


### PR DESCRIPTION
The proxy settings were being saved but not applied when creating the LightClient. This fix ensures proxy configuration is passed from Electron settings through the native bindings to the Rust backend.

Changes:
- Updated native bindings to accept proxyEnabled and proxyUrl parameters
- Modified litelib_initialize_existing(), litelib_initialize_new(), and litelib_initialize_new_from_phrase() to apply proxy config
- Updated TypeScript type definitions for new parameters
- Modified LoadingScreen to load and pass proxy settings from Electron
- Added proxyEnabled and proxyUrl to LoadingScreenState

Now when user selects Tor server and restarts wallet, the proxy configuration will be correctly applied to all gRPC connections.

Fixes the issue where wallet showed regular server after selecting Tor.