### PR TITLE
fix: Correct native module path in packaged app

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -13,7 +13,7 @@ try {
     native = require(path.join(__dirname, '..', 'src', 'native.node'));
   } else {
     // In production, the native module should be in the unpacked directory
-    const unpackedPath = path.join(process.resourcesPath, 'app.asar.unpacked', 'src', 'native.node');
+    const unpackedPath = path.join(process.resourcesPath, 'app.asar.unpacked', 'build', 'native.node');
     native = require(unpackedPath);
   }
 } catch (error) {


### PR DESCRIPTION
- Change production path from src/native.node to build/native.node
- Aligns with build process that copies to build/ directory
- Fixes crash: 'Cannot find module app.asar.unpacked/src/native.node'
- Matches asarUnpack config in package.json