### PR TITLE
fix: Include Tor binaries in packaged app and fix path

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,8 @@
     "afterAllArtifactBuild": "./afterSignHook.js",
     "files": [
       "build/**/*",
-      "node_modules/**/*"
+      "node_modules/**/*",
+      "resources/**/*"
     ],
     "asarUnpack": [
       "src/native.node",

--- a/public/tor-manager.js
+++ b/public/tor-manager.js
@@ -39,9 +39,9 @@ class TorManager {
       return torBinary;
     }
 
-    // Production: use bundled Tor
+    // Production: use bundled Tor from unpacked resources
     const resourcesPath = process.resourcesPath;
-    const torPath = path.join(resourcesPath, 'tor', platform, torBinary);
+    const torPath = path.join(resourcesPath, 'app.asar.unpacked', 'resources', 'tor', platform, torBinary);
 
     return torPath;
   }


### PR DESCRIPTION
- Add resources/**/* to package.json files array
- Fix tor-manager.js to load Tor from app.asar.unpacked/resources/tor
- Resolves 0% Tor progress issue in production builds
- Ensures Tor binary is copied and found correctly