### PR TITLE
fix: Prevent Tor binary code signing failure in macOS builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,15 +182,19 @@
     "afterAllArtifactBuild": "./afterSignHook.js",
     "files": [
       "build/**/*",
-      "node_modules/**/*",
-      "resources/**/*"
+      "node_modules/**/*"
+    ],
+    "extraResources": [
+      {
+        "from": "resources/tor",
+        "to": "tor"
+      }
     ],
     "asarUnpack": [
       "src/native.node",
       "build/native.node",
       "build/native-*.node",
       "build/static/js/native-*.node",
-      "resources/tor/**/*",
       "lib/zcash-params/*",
       "public/tor-manager.js"
     ],

--- a/public/tor-manager.js
+++ b/public/tor-manager.js
@@ -39,9 +39,9 @@ class TorManager {
       return torBinary;
     }
 
-    // Production: use bundled Tor from unpacked resources
+    // Production: use bundled Tor from extraResources
     const resourcesPath = process.resourcesPath;
-    const torPath = path.join(resourcesPath, 'app.asar.unpacked', 'resources', 'tor', platform, torBinary);
+    const torPath = path.join(resourcesPath, 'tor', platform, torBinary);
 
     return torPath;
   }

--- a/scripts/post-build.js
+++ b/scripts/post-build.js
@@ -85,4 +85,20 @@ if (!fs.existsSync(nativeLoaderPath)) {
   console.log('Post-build: Created native-loader.js wrapper in build directory');
 }
 
+// Strip existing signature from Tor binary on macOS to avoid code signing conflicts
+if (process.platform === 'darwin') {
+  const { execSync } = require('child_process');
+  const torBinary = path.join(__dirname, '..', 'resources', 'tor', 'darwin', 'tor');
+
+  if (fs.existsSync(torBinary)) {
+    try {
+      console.log('Post-build: Stripping signature from Tor binary...');
+      execSync(`codesign --remove-signature "${torBinary}"`, { stdio: 'inherit' });
+      console.log('Post-build: Successfully stripped Tor binary signature');
+    } catch (error) {
+      console.warn('Post-build: Warning - could not strip Tor signature:', error.message);
+    }
+  }
+}
+
 console.log('Post-build: Complete');


### PR DESCRIPTION
- Move Tor binaries to extraResources instead of files array
- Prevents electron-builder from signing Tor with hardened runtime
- Update tor-manager.js path from app.asar.unpacked/resources to Resources
- Strip existing ad-hoc signature in post-build script
- Fixes: 'main executable failed strict validation' error