### PR TITLE
fix: Exclude Tor binaries from macOS code signing

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,7 +235,10 @@
       "gatekeeperAssess": false,
       "entitlements": "./configs/entitlements.mac.minimal.plist",
       "entitlementsInherit": "./configs/entitlements.mac.minimal.plist",
-      "notarize": false
+      "notarize": false,
+      "binaries": [
+        "!Contents/Resources/tor/**/*"
+      ]
     },
     "dmg": {
       "sign": false,


### PR DESCRIPTION
- Add binaries exclusion pattern for Contents/Resources/tor/**/*
- Prevents electron-builder from signing Tor with hardened runtime
- Fixes 'main executable failed strict validation' error