### PR TITLE
fix: Use afterPack/afterSign hooks to bypass Tor signing

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,8 @@
   "build": {
     "productName": "BitcoinZ Blue",
     "appId": "com.bitcoinz.blue",
-    "afterSign": "./afterSignHook.js",
+    "afterPack": "./scripts/electron-hooks.js",
+    "afterSign": "./scripts/electron-hooks.js",
     "afterAllArtifactBuild": "./afterSignHook.js",
     "files": [
       "build/**/*",
@@ -235,10 +236,7 @@
       "gatekeeperAssess": false,
       "entitlements": "./configs/entitlements.mac.minimal.plist",
       "entitlementsInherit": "./configs/entitlements.mac.minimal.plist",
-      "notarize": false,
-      "binaries": [
-        "!Contents/Resources/tor/**/*"
-      ]
+      "notarize": false
     },
     "dmg": {
       "sign": false,

--- a/scripts/electron-hooks.js
+++ b/scripts/electron-hooks.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Electron-builder afterPack hook
+ * Moves Tor binary out of the app before code signing to avoid hardened runtime conflicts
+ */
+exports.afterPack = async function(context) {
+  const appOutDir = context.appOutDir;
+  const platform = context.packager.platform.name;
+
+  console.log(`[afterPack] Running for platform: ${platform}`);
+
+  if (platform === 'mac') {
+    const appPath = path.join(appOutDir, `${context.packager.appInfo.productName}.app`);
+    const torDir = path.join(appPath, 'Contents', 'Resources', 'tor');
+    const tempTorDir = path.join(appOutDir, '.temp-tor');
+
+    if (fs.existsSync(torDir)) {
+      console.log('[afterPack] Moving Tor binaries out of app before signing...');
+      console.log(`  From: ${torDir}`);
+      console.log(`  To: ${tempTorDir}`);
+
+      // Move entire tor directory to temp location
+      fs.renameSync(torDir, tempTorDir);
+
+      console.log('[afterPack] ✅ Tor binaries moved successfully');
+    } else {
+      console.log('[afterPack] ⚠️  Tor directory not found, skipping');
+    }
+  }
+};
+
+/**
+ * Electron-builder afterSign hook
+ * Moves Tor binary back into the app after code signing is complete
+ */
+exports.afterSign = async function(context) {
+  const appOutDir = context.appOutDir;
+  const platform = context.packager.platform.name;
+
+  console.log(`[afterSign] Running for platform: ${platform}`);
+
+  if (platform === 'mac') {
+    const appPath = path.join(appOutDir, `${context.packager.appInfo.productName}.app`);
+    const torDir = path.join(appPath, 'Contents', 'Resources', 'tor');
+    const tempTorDir = path.join(appOutDir, '.temp-tor');
+
+    if (fs.existsSync(tempTorDir)) {
+      console.log('[afterSign] Moving Tor binaries back into app after signing...');
+      console.log(`  From: ${tempTorDir}`);
+      console.log(`  To: ${torDir}`);
+
+      // Ensure Resources directory exists
+      const resourcesDir = path.join(appPath, 'Contents', 'Resources');
+      if (!fs.existsSync(resourcesDir)) {
+        fs.mkdirSync(resourcesDir, { recursive: true });
+      }
+
+      // Move tor directory back
+      fs.renameSync(tempTorDir, torDir);
+
+      console.log('[afterSign] ✅ Tor binaries restored successfully');
+    } else {
+      console.log('[afterSign] ⚠️  Temp Tor directory not found, skipping');
+    }
+  }
+};


### PR DESCRIPTION
- Create electron-hooks.js with afterPack and afterSign functions
- Move Tor binaries out before signing, restore after signing
- Prevents 'main executable failed strict validation' error
- Remove non-working binaries exclusion pattern
- Tor remains unsigned (acceptable for bundled tools)