### PR TITLE
fix: Create window before starting Tor to receive progress events

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -789,7 +789,13 @@ app.whenReady().then(async () => {
   const allSettings = await settings.get("all");
   const proxyEnabled = allSettings?.proxy?.enabled || false;
 
-  // Start Tor if proxy is enabled
+  // Create window FIRST
+  createWindow();
+
+  // Set mainWindow reference on torManager for IPC events
+  torManager.setMainWindow(mainWindow);
+
+  // Start Tor AFTER window is created and mainWindow is set
   if (proxyEnabled) {
     console.log("[Electron] Proxy enabled, starting Tor...");
     try {
@@ -801,11 +807,6 @@ app.whenReady().then(async () => {
   } else {
     console.log("[Electron] Proxy disabled, Tor will not start");
   }
-
-  createWindow();
-
-  // Set mainWindow reference on torManager for IPC events
-  torManager.setMainWindow(mainWindow);
 });
 
 // Stop Tor when app is quitting


### PR DESCRIPTION
Problem: Tor started before window creation, so mainWindow was null when Tor tried to send progress events (0%, 5%, 10%...). LoadingScreen never received updates, showing stuck at 0%.

Fix: Reorder initialization:
1. Create window first
2. Set mainWindow on torManager
3. Then start Tor (so events can be sent)

Now progress events properly reach the LoadingScreen UI.